### PR TITLE
Add standard .NET .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# .NET build results
+bin/
+obj/
+
+# Visual Studio
+.vs/
+*.user
+*.suo
+
+# Logs
+*.log


### PR DESCRIPTION
## Summary
- add `.gitignore` with common .NET exclusions for build output, Visual Studio settings, and logs

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68921e157a2c832db7a80b7701c97c27